### PR TITLE
[BUGFIX] Issue #75 & [CLEANUP] Issue #85

### DIFF
--- a/Classes/Utility/ProductUtility.php
+++ b/Classes/Utility/ProductUtility.php
@@ -336,7 +336,9 @@ class ProductUtility
             $quantity = intval($request->getArgument('quantity'));
             $cartProductValues['quantity'] = $quantity ? $quantity : 1;
         }
-
+        if ($request->hasArgument('additional')) {
+            $cartProductValues['additional'] = ($request->getArgument('additional'));
+        }
         if ($request->hasArgument('feVariants')) {
             $requestFeVariants = $request->getArgument('feVariants');
             if (is_array($requestFeVariants)) {

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -36,6 +36,8 @@ call_user_func(function () {
                 'foreign_table' => 'tx_cartproducts_domain_model_product_product',
                 'minitems' => 0,
                 'maxitems' => 1,
+                'default' => 0,
+                'size' => 1,
             ],
         ],
     ];

--- a/Resources/Private/Partials/Product/CartForm.html
+++ b/Resources/Private/Partials/Product/CartForm.html
@@ -11,7 +11,7 @@
             controller="Cart\Product"
             action="add"
             method="post"
-            pageType="{f:if(condition:'{settings.addToCartByAjax}', then:'{settings.addToCartByAjax}', else:'')}"
+            pageType="{settings.addToCartByAjax}"
             additionalAttributes="{data-ajax: '{f:if(condition: \'{settings.addToCartByAjax}\', then: \'1\', else: \'0\')}', data-type: 'slot', data-id: '{slot.uid}'}">
         <input type="hidden" name="tx_cart_cart[productType]" value="CartProducts">
         <input type="hidden" name="tx_cart_cart[product]" value="{product.uid}">


### PR DESCRIPTION
# [BUGFIX] Issue #75 
- Adding 'default' => 0, to fix the Issue (See sources: Note from Oliver Hader)
- Adding 'size' => 1 to improve the display at the selected min/max

**Source:**
- https://stackoverflow.com/a/50138799

# [CLEANUP] Issue #85
The original definition in pageType leads to a "TypeError" with plugin.tx_cart.settings.addToCartByAjax = 0.

Possible solution:
1. `pageType="{f:if(condition:'{settings.addToCartByAjax}', then:'{settings.addToCartByAjax}', else:'{settings.addToCartByAjax}'')}"`
2. `pageType="{f:if(condition:'{settings.addToCartByAjax}', then:'{settings.addToCartByAjax}', else:'0'')}"`
3. `pageType="{settings.addToCartByAjax}"`

I decided to use solution 3, because it makes this point clearer. Furthermore with addToCartByAjax the PageType is defined. If you don't want to use the Ajax function you set addToCartByAjax = 0. For this reason no condition is needed at this point.

# [FEATURE] Make [additional] accessible
Make [additional] accessible to pass additional information to Cart