### PR TITLE
[BUGFIX] fixes for TYPO3 10

### DIFF
--- a/Classes/Domain/Model/Product/BeVariant.php
+++ b/Classes/Domain/Model/Product/BeVariant.php
@@ -455,7 +455,7 @@ class BeVariant extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
      */
     public function getBestSpecialPricePercentageDiscount($frontendUserGroupIds = [])
     {
-        if ($this->getPriceCalculated() !== 0) {
+        if ($this->getPriceCalculated() !== 0 && $this->getPriceCalculated() !== 0.0) {
             $bestSpecialPricePercentageDiscount = (($this->getBestSpecialPriceDiscount($frontendUserGroupIds)) / $this->getPriceCalculated()) * 100;
         }
 

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -21,10 +21,5 @@ return [
     ],
     \Extcode\CartProducts\Domain\Model\Category::class => [
         'tableName' => 'sys_category',
-        'properties' => [
-            'parentcategory' => [
-                'fieldName' => 'parent'
-            ],
-        ],
     ],
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -12,7 +12,7 @@ services:
       - name: event.listener
         identifier: 'cart-products--process-order-create--handle-stock'
         event: Extcode\Cart\Event\ProcessOrderCreateEvent
-        after: 'cart--process-order-create--order'
+        after: 'cart--process-order-create--order-number'
         before: 'cart--process-order-create--email'
 
   Extcode\CartProducts\EventListener\ProcessOrderCreate\FlushCache:


### PR DESCRIPTION
- data mapper fails to map _parent_ column to property -> this disables the possibility to filter for products of a certain categroy AND their subcategories -> mapping of property _parent_ to _parentcategory_ removed
- handle-stock event is placed after _order_, but should be after _order-number_ because otherwise this mixes up the Service _order_ and _order-number_ is executed after email -> E-Mail is missing orderNumber and orderDate