### PR TITLE
[TASK] Switch type of quantity input fields

### DIFF
--- a/Resources/Private/Partials/Product/CartForm.html
+++ b/Resources/Private/Partials/Product/CartForm.html
@@ -16,7 +16,7 @@
         <input type="hidden" name="tx_cart_cart[productType]" value="CartProducts">
         <input type="hidden" name="tx_cart_cart[product]" value="{product.uid}">
 
-        <input class="form-control" type="text" value="1" name="tx_cart_cart[quantity]">
+        <input class="form-control" type="number" value="1" name="tx_cart_cart[quantity]">
         <f:if condition="{product.beVariants}">
             <cartproducts:form.variantSelect
                     id="be-variants-select"

--- a/Resources/Private/Templates/Product/Flexform.html
+++ b/Resources/Private/Templates/Product/Flexform.html
@@ -10,7 +10,7 @@
                 controller="Cart\Product"
                 action="add">
             <input type="hidden" value="{contentId}" name="tx_cart_cart[contentId]">
-            <input type="text" value="1" name="tx_cart_cart[quantity]">
+            <input type="number" value="1" name="tx_cart_cart[quantity]">
             <f:form.submit class="btn btn-default" value="{f:translate(key: 'tx_cartproducts.add_product', default: '[add product]')}"/>
         </f:form>
     </div>


### PR DESCRIPTION
Form input fields which are used in the FE to
enter the quantity of products used
type="text". These fields now use
type="number" instead.

Additional fix for issue https://github.com/extcode/cart/issues/311