### PR TITLE
[TASK] Include `typo3/cms-reactions` as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
         "extcode/cart": "dev-main",
         "typo3/cms-core": "^12.4",
         "typo3/cms-extbase": "^12.4",
-        "typo3/cms-fluid": "^12.4"
+        "typo3/cms-fluid": "^12.4",
+        "typo3/cms-reactions": "^12.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.16",


### PR DESCRIPTION
The introduced `Extcode\CartProducts\Reaction\UpdateStockReaction` needs `typo3/cms-reactions` as dependency.

Fixes: #154