### PR TITLE
Set default value

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -39,6 +39,7 @@ call_user_func(function () {
                 'foreign_table' => 'tx_cartproducts_domain_model_product_product',
                 'minitems' => 0,
                 'maxitems' => 1,
+                'default' => 0
             ],
         ],
     ];


### PR DESCRIPTION
TCA needs a default value. Sometimes you get an DB error, if there is no default value

![image](https://github.com/extcode/cart_products/assets/7656278/926015bd-2220-40ec-b241-3490d7ca5554)
