### PR TITLE
[BUGFIX] Register Category model properly

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -104,3 +104,7 @@ $GLOBALS['TYPO3_CONF_VARS']['EXT']['cart_products']['templateLayouts']['products
 $GLOBALS['TYPO3_CONF_VARS']['EXT']['cart_products']['templateLayouts']['products'][] = [$_LLL_be . 'flexforms_template.templateLayout.products.grid', 'grid'];
 $GLOBALS['TYPO3_CONF_VARS']['EXT']['cart_products']['templateLayouts']['teaser_products'][] = [$_LLL_be . 'flexforms_template.templateLayout.products.table', 'table'];
 $GLOBALS['TYPO3_CONF_VARS']['EXT']['cart_products']['templateLayouts']['teaser_products'][] = [$_LLL_be . 'flexforms_template.templateLayout.products.grid', 'grid'];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Extbase\Domain\Model\Category::class] = [
+    'className' => \Extcode\CartProducts\Domain\Model\Category::class,
+];


### PR DESCRIPTION
To avoid an error when adding a category
to a product it's necessary to register the
extended Category model properly.

Fixes: #170