### PR TITLE
[BUGFIX] Fix the mapping of parent category on categories

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -26,10 +26,5 @@ return [
 
     Category::class => [
         'tableName' => 'sys_category',
-        'properties' => [
-            'parentcategory' => [
-                'fieldName' => 'parent',
-            ],
-        ],
     ],
 ];


### PR DESCRIPTION
The parent category of a product is always null.
This patch will fix the mapping.