### PR TITLE
[BUGFIX] Avoid error when plugin uses categories

### DIFF
--- a/Classes/Domain/Repository/Product/ProductRepository.php
+++ b/Classes/Domain/Repository/Product/ProductRepository.php
@@ -32,7 +32,7 @@ class ProductRepository extends Repository
         if ((!empty($demand->getCategories()))) {
             $categoryConstraints = [];
             foreach ($demand->getCategories() as $category) {
-                $categoryConstraints[] = $query->contains('category', $category);
+                $categoryConstraints[] = $query->equals('category', $category);
                 $categoryConstraints[] = $query->contains('categories', $category);
             }
             $constraints[] = $query->logicalOr(...array_values($categoryConstraints));


### PR DESCRIPTION
Adding a category in the BE of the plugin
`cartproducts_products` does no longer throw an
error.

Fixes: #179