### PR TITLE
[BUGFIX] Remove JS assets which was added twice

### DIFF
--- a/Resources/Private/Partials/Product/CartForm.html
+++ b/Resources/Private/Partials/Product/CartForm.html
@@ -55,5 +55,4 @@
     </f:form>
 </div>
 
-<f:asset.script identifier="add-to-cart" src="EXT:cart/Resources/Public/JavaScripts/add_to_cart.js" />
 </html>


### PR DESCRIPTION
The `add_to_cart.js` was added twice. The real
problem is that it was with a wrong path added
the second time. As a result the JS was not loaded at all because both asset ViewHelper tags had the same key.

Fixes: #183