### PR TITLE
[TASK] Add UpdateWizard for image references

### DIFF
--- a/Classes/Updates/ImageReferencesUpgradeWizard.php
+++ b/Classes/Updates/ImageReferencesUpgradeWizard.php
@@ -59,7 +59,7 @@ final class ImageReferencesUpgradeWizard implements UpgradeWizardInterface
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE_NAME);
         $queryBuilder->getRestrictions()->removeAll();
-        $records = $queryBuilder->select('uid')
+        $count = $queryBuilder->count('uid')
             ->from(self::TABLE_NAME)->where(
                 $queryBuilder->expr()->eq(
                     'fieldname',
@@ -69,9 +69,9 @@ final class ImageReferencesUpgradeWizard implements UpgradeWizardInterface
                     'tablenames',
                     $queryBuilder->createNamedParameter(self::IDENTIFIER, Connection::PARAM_STR)
                 ),
-            )->executeQuery()->fetchAllAssociative();
+            )->executeQuery()->fetchOne();
 
-        return count($records) > 0;
+        return (bool)$count;
     }
 
     public function getPrerequisites(): array

--- a/Classes/Updates/ImageReferencesUpgradeWizard.php
+++ b/Classes/Updates/ImageReferencesUpgradeWizard.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extcode\CartProducts\Updates;
+
+/*
+ * This file is part of the package extcode/cart-products.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+#[UpgradeWizard('cartProducts_updateImageReferences')]
+final class ImageReferencesUpgradeWizard implements UpgradeWizardInterface
+{
+    public const TABLE_NAME = 'sys_file_reference';
+    public const IDENTIFIER = 'tx_cartproducts_domain_model_product_product';
+
+    public function getTitle(): string
+    {
+        return 'Updates image references for EXT:cart_products';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Up to TYPO3 version 11 the image references of EXT:cart_products used  the key "image" for image references in the column `fieldname` of table `sys_file_reference`. This changed with the version for TYPO3 v12 where instead the key "images" is used. This wizard updates all references.';
+    }
+
+    public function executeUpdate(): bool
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file_reference');
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->update(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'tablenames',
+                    $queryBuilder->createNamedParameter(self::IDENTIFIER, Connection::PARAM_STR)
+                ),
+                $queryBuilder->expr()->eq(
+                    'fieldname',
+                    $queryBuilder->createNamedParameter('image', Connection::PARAM_STR)
+                ),
+            )
+            ->set('fieldname', 'images')
+            ->executeStatement();
+
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll();
+        $records = $queryBuilder->select('uid')
+            ->from(self::TABLE_NAME)->where(
+                $queryBuilder->expr()->eq(
+                    'fieldname',
+                    $queryBuilder->createNamedParameter('image', Connection::PARAM_STR)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tablenames',
+                    $queryBuilder->createNamedParameter(self::IDENTIFIER, Connection::PARAM_STR)
+                ),
+            )->executeQuery()->fetchAllAssociative();
+
+        return count($records) > 0;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+}

--- a/Documentation/Changelog/5.0/Breaking-186-ChangedKeyForImageReferences.rst
+++ b/Documentation/Changelog/5.0/Breaking-186-ChangedKeyForImageReferences.rst
@@ -1,0 +1,28 @@
+.. include:: ../../Includes.txt
+
+================================================
+Breaking: #186 - Changed key for image reference
+================================================
+
+See :issue:`186`
+
+Description
+===========
+
+With the version for TYPO3 v12 the references uses the key 'images' in
+column `fieldname` of table `sys_file_reference`. Before the key was 'image'
+(singular). Due to this the images are no longer shown, neither in the backend
+nor in the frontend. 
+
+Affected Installations
+======================
+
+All installations which are not set up with version 5 of EXT:cart_products
+(before TYPO3 v12).
+
+Migration
+=========
+
+Run the UpdateWizard "Updates image references for EXT:cart_products".
+
+.. index:: Database


### PR DESCRIPTION
With the version for TYPO3 v12 the image
references uses the key 'images' in column
`fieldname` of table `sys_file_reference`.
This UpdateWizards updates the old references.

Fixes: #186