### PR TITLE
[TASK] Use Context API to get user data

### DIFF
--- a/Classes/EventListener/RetrieveProductsFromRequest.php
+++ b/Classes/EventListener/RetrieveProductsFromRequest.php
@@ -11,17 +11,15 @@ namespace Extcode\CartProducts\EventListener;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Domain\Model\FrontendUser;
-use Extcode\Cart\Domain\Repository\FrontendUserRepository;
 use Extcode\Cart\Event\RetrieveProductsFromRequestEvent;
 use Extcode\CartProducts\Domain\Repository\Product\ProductRepository;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Core\Context\Context;
 
 class RetrieveProductsFromRequest
 {
     public function __construct(
+        private readonly Context $context,
         private readonly EventDispatcherInterface $eventDispatcher,
         protected ProductRepository $productRepository
     ) {}
@@ -54,33 +52,6 @@ class RetrieveProductsFromRequest
 
     protected function getFrontendUserGroupIds(): array
     {
-        $feGroupIds = [];
-
-        $user = $GLOBALS['TSFE']->fe_user->user;
-        if (!$user || !(int)$user['uid']) {
-            return $feGroupIds;
-        }
-
-        $feGroups = $this->getFeGroups((int)$user['uid']);
-        if ($feGroups) {
-            foreach ($feGroups as $feGroup) {
-                $feGroupIds[] = $feGroup->getUid();
-            }
-        }
-
-        return $feGroupIds;
-    }
-
-    protected function getFeGroups(int $uid): ?ObjectStorage
-    {
-        $frontendUserRepository = GeneralUtility::makeInstance(
-            FrontendUserRepository::class
-        );
-        $feUser = $frontendUserRepository->findByUid((int)$uid);
-        if (!$feUser instanceof FrontendUser) {
-            return null;
-        }
-
-        return $feUser->getUsergroup();
+        return $this->context->getPropertyFromAspect('frontend.user', 'groupIds') ?? [];
     }
 }

--- a/Classes/ViewHelpers/Product/AbstractProductViewHelper.php
+++ b/Classes/ViewHelpers/Product/AbstractProductViewHelper.php
@@ -9,18 +9,17 @@ namespace Extcode\CartProducts\ViewHelpers\Product;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Domain\Model\FrontendUser;
-use Extcode\Cart\Domain\Repository\FrontendUserRepository;
 use Extcode\CartProducts\Domain\Model\Product\Product;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 abstract class AbstractProductViewHelper extends AbstractViewHelper
 {
-    /**
-     * @var bool
-     */
     protected $escapeOutput = false;
+
+    public function __construct(
+        private readonly Context $context,
+    ) {}
 
     public function initializeArguments(): void
     {
@@ -34,39 +33,8 @@ abstract class AbstractProductViewHelper extends AbstractViewHelper
         );
     }
 
-    /**
-     * Get Frontend User Group
-     *
-     * @return array
-     */
-    protected function getFrontendUserGroupIds()
+    protected function getFrontendUserGroupIds(): array
     {
-        $user = $GLOBALS['TSFE']->fe_user->user;
-        if (!$user || !(int)$user['uid']) {
-            return [];
-        }
-
-        return $this->getFrontendUserIds((int)$user['uid']);
-    }
-
-    protected function getFrontendUserIds(int $feUserId): array
-    {
-        $feGroupIds = [];
-
-        $frontendUserRepository = GeneralUtility::makeInstance(
-            FrontendUserRepository::class
-        );
-        $feUser = $frontendUserRepository->findByUid($feUserId);
-
-        if (!$feUser instanceof FrontendUser) {
-            return [];
-        }
-
-        $feGroups = $feUser->getUsergroup();
-        foreach ($feGroups as $feGroup) {
-            $feGroupIds[] = $feGroup->getUid();
-        }
-
-        return $feGroupIds;
+        return $this->context->getPropertyFromAspect('frontend.user', 'groupIds') ?? [];
     }
 }

--- a/Classes/ViewHelpers/Product/IfBestSpecialPriceAvailableViewHelper.php
+++ b/Classes/ViewHelpers/Product/IfBestSpecialPriceAvailableViewHelper.php
@@ -9,9 +9,8 @@ namespace Extcode\CartProducts\ViewHelpers\Product;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Domain\Model\FrontendUser;
-use Extcode\Cart\Domain\Repository\FrontendUserRepository;
 use Extcode\CartProducts\Domain\Model\Product\Product;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
@@ -46,34 +45,9 @@ class IfBestSpecialPriceAvailableViewHelper extends AbstractConditionViewHelper
         return $bestSpecialPrice < $product->getMinPrice();
     }
 
-    /**
-     * Get Frontend User Group
-     *
-     * @return array
-     */
     protected static function getFrontendUserGroupIds(): array
     {
-        $user = $GLOBALS['TSFE']->fe_user->user;
-        if (!$user || !(int)$user['uid']) {
-            return [];
-        }
-
-        $feGroupIds = [];
-
-        $frontendUserRepository = GeneralUtility::makeInstance(
-            FrontendUserRepository::class
-        );
-        $feUser = $frontendUserRepository->findByUid((int)$user['uid']);
-
-        if (!$feUser instanceof FrontendUser) {
-            return [];
-        }
-
-        $feGroups = $feUser->getUsergroup();
-        foreach ($feGroups as $feGroup) {
-            $feGroupIds[] = $feGroup->getUid();
-        }
-
-        return $feGroupIds;
+        $context = GeneralUtility::makeInstance(Context::class);
+        return $context->getPropertyFromAspect('frontend.user', 'groupIds') ?? [];
     }
 }


### PR DESCRIPTION
Avoid usage of `$GLOBALS['TSFE']->fe_user`
the Context API is used instead.

The usage of `$GLOBALS['TSFE']->fe_user` in
the ProductController is not migrated because it
might be removed at all with #200.

Fixes: #114