### PR TITLE
[TASK] Only localized records in Teaser plugin

### DIFF
--- a/Configuration/FlexForms/TeaserProductsPlugin.xml
+++ b/Configuration/FlexForms/TeaserProductsPlugin.xml
@@ -40,6 +40,7 @@
                         <config>
                             <type>select</type>
                             <foreign_table>tx_cartproducts_domain_model_product_product</foreign_table>
+                            <foreign_table_where>AND tx_cartproducts_domain_model_product_product.sys_language_uid = ###REC_FIELD_sys_language_uid###</foreign_table_where>
                             <size>3</size>
                             <minitems>1</minitems>
                             <maxitems>99</maxitems>


### PR DESCRIPTION
It's no longer possible to select records from
another language than the current one in the
Teaser plugin.