### PR TITLE
Add user group access rights

### DIFF
--- a/Classes/Domain/Model/Product/Product.php
+++ b/Classes/Domain/Model/Product/Product.php
@@ -44,6 +44,8 @@ class Product extends AbstractProduct
     protected bool $isNetPrice = false;
 
     protected float $price = 0.0;
+    
+    protected $feGroup = '';
 
     /**
      * @var ObjectStorage<SpecialPrice>
@@ -466,5 +468,15 @@ class Product extends AbstractProduct
         }
 
         return $minPrice;
+    }
+
+    public function getFeGroup(): string
+    {
+        return $this->feGroup;
+    }
+
+    public function setFeGroup($feGroup): void
+    {
+        $this->feGroup = $feGroup;
     }
 }

--- a/Configuration/TCA/tx_cartproducts_domain_model_product_product.php
+++ b/Configuration/TCA/tx_cartproducts_domain_model_product_product.php
@@ -29,6 +29,7 @@ return [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
+            'fe_group' => 'fe_group',
         ],
         'searchFields' => 'sku,title,teaser,description,price,',
         'iconfile' => 'EXT:cart_products/Resources/Public/Icons/tx_cartproducts_domain_model_product_product.svg',
@@ -73,7 +74,11 @@ return [
             'showitem' => 'hidden;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:hidden_formlabel',
         ],
         'access' => [
-            'showitem' => 'starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:starttime_formlabel, endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:endtime_formlabel',
+            'showitem' => '
+                starttime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:starttime_formlabel, 
+                endtime;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:endtime_formlabel,
+                --linebreak--,
+                fe_group;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:fe_group_formlabel,',
         ],
         'be_variant_attributes' => [
             'showitem' => 'be_variant_attribute1, be_variant_attribute2, be_variant_attribute3, --linebreak--, be_variants',
@@ -163,7 +168,32 @@ return [
                 ],
             ],
         ],
-
+        'fe_group' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'size' => 5,
+                'maxitems' => 20,
+                'items' => [
+                    [
+                        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hide_at_login',
+                        'value' => -1,
+                    ],
+                    [
+                        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.any_login',
+                        'value' => -2,
+                    ],
+                    [
+                        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.usergroups',
+                        'value' => '--div--',
+                    ],
+                ],
+                'exclusiveKeys' => '-1,-2',
+                'foreign_table' => 'fe_groups',
+            ],
+        ],
         'product_type' => [
             'exclude' => 1,
             'label' => $_LLL . ':tx_cartproducts_domain_model_product_product.product_type',


### PR DESCRIPTION
This update introduces user group access rights, enabling a flexible option for managing product visibility based on user groups. This feature allows a private shop to run alongside a public shop, where certain products can be hidden from public view and shown only to logged-in customers or specific user groups.

**Use Case**
This functionality is valuable for shops that need to offer exclusive products or pricing to members, such as registered customers or particular user groups, while keeping other products available to all users.