### PR TITLE
[BUGFIX] Kill geckodriver before switching nix-shell environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -123,6 +123,7 @@ let
       ./vendor/bin/codecept run
 
       pgrep -f "php -S" | xargs -r kill
+      pgrep -f "geckodriver" | xargs -r kill
     '';
   };
 


### PR DESCRIPTION
Relates: #240