### PR TITLE
[BUGFIX] Add missing value for area divider item

### DIFF
--- a/Configuration/TCA/tx_cartproducts_domain_model_product_bevariant.php
+++ b/Configuration/TCA/tx_cartproducts_domain_model_product_bevariant.php
@@ -274,7 +274,7 @@ return [
                     ['label' => $_LLL . ':tx_cartproducts_domain_model_product_product.measure.length', 'value' => '--div--'],
                     ['label' => 'cm', 'value' => 'cm'],
                     ['label' => 'm', 'value' => 'm'],
-                    ['label' => $_LLL . ':tx_cartproducts_domain_model_product_product.measure.area'],
+                    ['label' => $_LLL . ':tx_cartproducts_domain_model_product_product.measure.area', 'value' => '--div--'],
                     ['label' => 'm²', 'value' => 'm2'],
                 ],
                 'size' => 1,


### PR DESCRIPTION
## Summary
- Fix malformed TCA item in `price_measure_unit` for backend variants.
- Add missing `'value' => '--div--'` to the `measure.area` divider entry.
- Prevent backend save warning (`Undefined array key "value"`) in TYPO3 DataHandler.

## Problem
In `Configuration/TCA/tx_cartproducts_domain_model_product_bevariant.php`, the item
`tx_cartproducts_domain_model_product_product.measure.area` is defined without a `value`.
TYPO3 expects `items` entries to contain a `value` and can trigger:
`PHP Warning: Undefined array key "value"` during save.

## Change
Updated:
```php
['label' => $_LLL . ':tx_cartproducts_domain_model_product_product.measure.area', 'value' => '--div--'],
```

## References
- Related issue:  #282 